### PR TITLE
Encode HTML as UTF-8 before base64 encoding

### DIFF
--- a/mailviews/previews.py
+++ b/mailviews/previews.py
@@ -178,7 +178,7 @@ class Preview(object):
                 if alternative[1] == 'text/html')
             context.update({
                 'html': html,
-                'escaped_html': b64encode(html),
+                'escaped_html': b64encode(html.encode('utf-8')),
             })
         except StopIteration:
             pass


### PR DESCRIPTION
I had some issues with email templates that contained UTF-8 characters during the base64 encoding in the previews. Encoding the HTML as UTF-8 before applying `b64encode` fixed the problem for me. What do you think about it? Let me know if there's more that need to be done for this to get considered for merging.
