### PR TITLE
Fix a Django 1.7 issue with importing INSTALLED_APPS modules

### DIFF
--- a/mailviews/previews.py
+++ b/mailviews/previews.py
@@ -210,19 +210,23 @@ def autodiscover():
     """
     from django.conf import settings
     for application in settings.INSTALLED_APPS:
-        module = import_module(application)
+        # As of Django 1.7, settings.INSTALLED_APPS may contain classes instead of modules, hence the try/except
+        # See here: https://docs.djangoproject.com/en/dev/releases/1.7/#introspecting-applications
+        try:
+            module = import_module(application)
 
-        if module_has_submodule(module, 'emails'):
-            emails = import_module('%s.emails' % application)
-            try:
-                import_module('%s.emails.previews' % application)
-            except ImportError:
-                # Only raise the exception if this module contains previews and
-                # there was a problem importing them. (An emails module that
-                # does not contain previews is not an error.)
-                if module_has_submodule(emails, 'previews'):
-                    raise
-
+            if module_has_submodule(module, 'emails'):
+                emails = import_module('%s.emails' % application)
+                try:
+                    import_module('%s.emails.previews' % application)
+                except ImportError:
+                    # Only raise the exception if this module contains previews and
+                    # there was a problem importing them. (An emails module that
+                    # does not contain previews is not an error.)
+                    if module_has_submodule(emails, 'previews'):
+                        raise
+        except ImportError:
+            pass
 
 #: The default preview site.
 site = PreviewSite()


### PR DESCRIPTION
I ran into this issue because I was trying to use the new [SimpleAdminConfig](http://django.readthedocs.org/en/1.7.x/ref/contrib/admin/index.html#django.contrib.admin.apps.SimpleAdminConfig) in Django 1.7. Now that `INSTALLED_APPS` can contain classes (and not just modules), a possible ImportError needs to be caught within the preview autodiscover function.

According to the 1.7 release notes, the proper way to access "INSTALLED_APPS" is through the new "App registry", but if we did that here then mailviews would become incompatible with previous versions of Django.