### PR TITLE
Django 1.8 and python3 compatibilty

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,12 +15,13 @@ env:
     - DJANGO='Django>=1.5,<1.6'
     - DJANGO='Django>=1.6,<1.7'
     - DJANGO='Django>=1.7,<1.8'
+    - DJANGO='Django>=1.8,<1.9'
 
 matrix:
     exclude:
-        - env: DJANGO='Django>=1.6,<1.7'
-          python: "2.6"
         - env: DJANGO='Django>=1.7,<1.8'
+          python: "2.6"
+        - env: DJANGO='Django>=1.8,<1.9'
           python: "2.6"
         - env: DJANGO='Django>=1.3,<1.4'
           python: "3.4"

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,10 +9,18 @@ python:
     - "2.7"
 
 env:
-    matrix:
-        - DJANGO='Django>=1.3,<1.4'
-        - DJANGO='Django>=1.4,<1.5'
-        - DJANGO='Django>=1.5,<1.6'
+    - DJANGO='Django>=1.3,<1.4'
+    - DJANGO='Django>=1.4,<1.5'
+    - DJANGO='Django>=1.5,<1.6'
+    - DJANGO='Django>=1.6,<1.7'
+    - DJANGO='Django>=1.7,<1.8'
+
+matrix:
+    exclude:
+        - env: DJANGO='Django>=1.6,<1.7'
+          python: "2.6"
+        - env: DJANGO='Django>=1.7,<1.8'
+          python: "2.6"
 
 install:
     - pip install --use-mirrors $DJANGO

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ notifications:
 python:
     - "2.6"
     - "2.7"
+    - "3.4"
 
 env:
     - DJANGO='Django>=1.3,<1.4'
@@ -21,6 +22,10 @@ matrix:
           python: "2.6"
         - env: DJANGO='Django>=1.7,<1.8'
           python: "2.6"
+        - env: DJANGO='Django>=1.3,<1.4'
+          python: "3.4"
+        - env: DJANGO='Django>=1.4,<1.5'
+          python: "3.4"
 
 install:
     - pip install --use-mirrors $DJANGO

--- a/mailviews/tests/__init__.py
+++ b/mailviews/tests/__init__.py
@@ -1,4 +1,5 @@
 from django.conf import settings
+import django
 
 if not settings.configured:
     settings.configure(
@@ -33,6 +34,8 @@ if not settings.configured:
         },
     )
 
+    if hasattr(django, 'setup'):
+        django.setup()
 
 from mailviews.tests.tests import *  # NOQA
 

--- a/mailviews/tests/emails/previews.py
+++ b/mailviews/tests/emails/previews.py
@@ -1,12 +1,14 @@
 import random
 
 from django import forms
-from django.contrib.webdesign.lorem_ipsum import paragraphs, words
 
 from mailviews.previews import Preview, site
 from mailviews.tests.emails.views import (BasicEmailMessageView,
     BasicHTMLEmailMessageView)
-
+try:
+    from django.utils.lorem_ipsum import words, paragraphs
+except ImportError:
+    from django.contrib.webdesign.lorem_ipsum import paragraphs, words
 
 class BasicPreview(Preview):
     message_view = BasicEmailMessageView

--- a/mailviews/tests/tests.py
+++ b/mailviews/tests/tests.py
@@ -244,8 +244,8 @@ class PreviewSiteTestCase(TestCase):
         })
         response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
-        self.assertIn('#body-plain', response.content)
-        self.assertIn('#raw', response.content)
+        self.assertContains(response, '#body-plain')
+        self.assertContains(response, '#raw')
 
     def test_basic_html_preview(self):
         url = reverse('%s:detail' % URL_NAMESPACE, kwargs={
@@ -254,9 +254,9 @@ class PreviewSiteTestCase(TestCase):
         })
         response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
-        self.assertIn('#html', response.content)
-        self.assertIn('#body-plain', response.content)
-        self.assertIn('#raw', response.content)
+        self.assertContains(response, '#html')
+        self.assertContains(response, '#body-plain')
+        self.assertContains(response, '#raw')
 
     def test_customizable_preview(self):
         url = reverse('%s:detail' % URL_NAMESPACE, kwargs={
@@ -265,6 +265,6 @@ class PreviewSiteTestCase(TestCase):
         })
         response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
-        self.assertIn('<form', response.content)
-        self.assertIn('#body-plain', response.content)
-        self.assertIn('#raw', response.content)
+        self.assertContains(response, '<form')
+        self.assertContains(response, '#body-plain')
+        self.assertContains(response, '#raw')

--- a/mailviews/tests/urls.py
+++ b/mailviews/tests/urls.py
@@ -1,4 +1,7 @@
-from django.conf.urls.defaults import include, patterns, url
+try:
+    from django.conf.urls import include, patterns, url
+except ImportError:
+    from django.conf.urls.defaults import include, patterns, url
 
 from mailviews.previews import autodiscover, site
 


### PR DESCRIPTION
I fixed some imports that changed with the update to django 1.8, but kept backwards compatibility by using a try catch statement with the old import. Instead of using `assertIn` the `response.content` I used the `assertContains` which is available back to 1.3 and solves issues with 1.8